### PR TITLE
Allow Router::url() to work without route translations.

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -103,9 +103,10 @@ class Router
         // Add locale to the host
         $parsed_url['host'] = $this->aliasLocale($locale).'.'.$this->getDomain();
 
-        // Resolve the route path for the given route name
-        if (!$parsed_url['path'] = $this->findRoutePathByName($routeName, $locale)) {
-            return false;
+        // Resolve the translated route path for the given route name
+        $translatedPath = $this->findRoutePathByName($routeName, $locale);
+        if ($translatedPath !== false) {
+            $parsed_url['path'] = $translatedPath;
         }
 
         // If attributes are given, substitute them in the path
@@ -265,7 +266,6 @@ class Router
         $parsed_url = parse_url(app()['request']->fullUrl());
 
         // Don't store path, query and fragment
-        unset($parsed_url['path']);
         unset($parsed_url['query']);
         unset($parsed_url['fragment']);
 


### PR DESCRIPTION
So, I want to have a working language switcher and be able to generate it using the handy `Router::getCurrentVersions()` method or I want a locale-specific URL using the `Router::current()` one.

The problem is that my routes aren't named and for now I don't want to translate them. This means that `Router::url()` always returns `false`.

This PR makes it work even if there are no translations for a route, just changing the subdomain, instead of returning `false` in `Router::url()`. For this to happen, I don't `unset` the `path` from the parsed URL and instead use it if no translated path exists, thus making the `url()` function work even if the routes are not named and there's nothing in `resources/lang`.

I'm not sure if it's possible with the current repo architecture, but it would be nice if this could be released for the 5.4 and 5.5 versions.

Gracias.