### PR TITLE
Add compatibility with Laravel 6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "illuminate/support": "^5.6",
-        "illuminate/container": "^5.6",
-        "illuminate/events": "^5.6"
+        "illuminate/support": "^6.0",
+        "illuminate/container": "^6.0",
+        "illuminate/events": "^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.0",
+        "phpunit/phpunit": "~8.0",
         "orchestra/testbench": "3.6.*",
         "orchestra/testbench-browser-kit": "3.6.*"
     },

--- a/src/Router.php
+++ b/src/Router.php
@@ -196,7 +196,7 @@ class Router
     protected function findRoutePathByName($routeName, $locale = null)
     {
         if (app()['translator']->has($routeName, $locale)) {
-            return app()['translator']->trans($routeName, [], $locale);
+            return app()['translator']->get($routeName, [], $locale);
         }
 
         return false;


### PR DESCRIPTION
Updates composer.json versions and replaces the Translator::trans() method with Translator::get() (https://laravel.com/docs/6.x/upgrade#trans-and-trans-choice)

Should probably push a new 6.0 tag after merging.
